### PR TITLE
Added column width changes

### DIFF
--- a/_extensions/clean/clean.scss
+++ b/_extensions/clean/clean.scss
@@ -296,3 +296,34 @@ $selection-bg: #26351c !default;
   height: auto;
   object-fit: contain;
 }
+
+// Change the relative widths of `output-location: column`.  Usage:
+// ```{python}
+// #| echo: true
+// #| output-location: column
+// #| classes: columns3070
+
+.reveal .columns3070 > div.column:first-child {
+  width: 30%;
+}
+.reveal .columns3070 div.column:not(:first-child) {
+  width: 70%;
+}
+.reveal .columns7030 > div.column:first-child {
+  width: 70%;
+}
+.reveal .columns7030 div.column:not(:first-child) {
+  width: 30%;
+}
+.reveal .columns4060 > div.column:first-child {
+  width: 40%;
+}
+.reveal .columns4060 div.column:not(:first-child) {
+  width: 60%;
+}      
+.reveal .columns6040 > div.column:first-child {
+  width: 60%;
+}
+.reveal .columns6040 div.column:not(:first-child) {
+  width: 40%;
+}      


### PR DESCRIPTION
This is a minor addition to the stylesheets.  See https://github.com/quarto-dev/quarto-cli/discussions/6950  for the suggestion from quarto people about the approach.

The goal is to change the relative size of the echo'd text and the output columns - which comes up reasonbly often when mixing code and output in lecture notes.  Usage in the CSS, but basically:

```
    ```{python}
    #| echo: true
    #| output-location: column
    #| classes: columns3070
    some_python_code() #etc.
    ```
```

No offense taken if you prefer not to add things like this to the styles.