### PR TITLE
Fix `mathjax-config.js` path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
-# template.html
+template.html
 template_files/
+mathjax-config.js

--- a/_extensions/clean/_extension.yml
+++ b/_extensions/clean/_extension.yml
@@ -13,6 +13,8 @@ contributes:
       html-math-method:
         method: mathjax
         url: "https://cdn.jsdelivr.net/npm/mathjax@4/tex-mml-chtml.js"
-      include-before-body: 
+      include-before-body:
         - text: |
-            <script src="_extensions/clean/mathjax-config.js"></script>
+            <script src="mathjax-config.js"></script>
+      format-resources:
+        - mathjax-config.js


### PR DESCRIPTION
Fixes #23 

(Hopefully... see https://github.com/grantmcdermott/quarto-revealjs-clean/pull/24#issuecomment-3382478569)

@hchulkim and @benthestatistician do you mind trying an install from this branch and seeing if it works. Either of the following should do:

```
quarto add grantmcdermott/quarto-revealjs-clean@fix-mathjax-path-resolution

# or
quarto use template grantmcdermott/quarto-revealjs-clean@fix-mathjax-path-resolution
```

 I have to jump over to meetings now, but will test later myself too.